### PR TITLE
change from cat to writeChar to keep additional newline from being added...

### DIFF
--- a/inst/app/server.R
+++ b/inst/app/server.R
@@ -164,7 +164,7 @@ shinyServer(function(input, output, session) {
   ### Save file logic ###
   observe({
     if (input$save > 0 | !is.null(input$save_key)){
-      isolate({cat(input$rmd, file = md_name)})
+      isolate({writeChar(input$rmd, con = md_name)})
     }
   })
   ### ###


### PR DESCRIPTION
... when saving on windows solving #2 

tested on both windows and mac osx and rendering and saving works as expected.
